### PR TITLE
Lock Truffle to 4.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "babel-polyfill": "^6.26.0",
     "babel-register": "^6.26.0",
     "solidity-coverage": "^0.5.4",
-    "truffle": "^4.1.11",
+    "truffle": "4.1.6",
     "web3-eth-abi": "^1.0.0-beta.34",
     "zeppelin-solidity": "1.8.0"
   },


### PR DESCRIPTION
If you install any version of truffle after this, truffle compile fails
because the version of solc it requires (0.4.24) produces compilation
errors

4.1.6 was the last version to ship with 0.4.21 of solc, which is also
the pragma mark version defined in the contracts

A CI build somewhere should help this - Travis? Does Tlon have any conventions here?