### PR TITLE
final refactor

### DIFF
--- a/contracts/ConditionalStarRelease.sol
+++ b/contracts/ConditionalStarRelease.sol
@@ -632,4 +632,20 @@ contract ConditionalStarRelease is Ownable
     {
       return commitments[_participant].stars;
     }
+
+    //  getConditionsState(): get the condition configurations and state
+    //
+    //    Note: only useful for clients, as Solidity does not currently
+    //    support returning dynamic arrays.
+    //
+    function getConditionsState()
+      external
+      view
+      returns (bytes32[] conds,
+               uint256[] lives,
+               uint256[] deads,
+               uint256[] times)
+    {
+      return (conditions, livelines, deadlines, timestamps);
+    }
 }

--- a/contracts/Constitution.sol
+++ b/contracts/Constitution.sol
@@ -711,7 +711,7 @@ contract Constitution is ConstitutionBase, ERC165Mapping, ERC721Metadata
     //    the voting proxy is allowed to start polls and cast votes
     //    on the ship's behalf.
     //
-    function setVotingProxy(uint32 _ship, address _voter)
+    function setVotingProxy(uint8 _ship, address _voter)
       external
       activeShipOwner(_ship)
     {

--- a/contracts/Constitution.sol
+++ b/contracts/Constitution.sol
@@ -268,16 +268,17 @@ contract Constitution is ConstitutionBase, ERC165Mapping, ERC721Metadata
   //  Urbit functions for all ships
   //
 
-    //  setManager(): configure the management address for all ships you own
+    //  setManagementProxy(): configure the management proxy for _ship
     //
-    //    The management address may perform "reversible" operations on
+    //    The management proxy may perform "reversible" operations on
     //    behalf of the owner. This includes public key configuration and
     //    operations relating to sponsorship.
     //
-    function setManager(address _manager)
+    function setManagementProxy(uint32 _ship, address _manager)
       external
+      activeShipOwner(_ship)
     {
-      ships.setManager(msg.sender, _manager);
+      ships.setManagementProxy(_ship, _manager);
     }
 
     //  configureKeys(): configure _ship with Urbit public keys _encryptionKey,
@@ -702,15 +703,16 @@ contract Constitution is ConstitutionBase, ERC165Mapping, ERC721Metadata
   //  Poll actions
   //
 
-    //  setDelegate(): configure the delegate address for all ships you own
+    //  setVotingProxy(): configure the voting proxy for _ship
     //
-    //    the delegate is allowed to start polls and cast votes
-    //    on the owner's behalf.
+    //    the voting proxy is allowed to start polls and cast votes
+    //    on the ship's behalf.
     //
-    function setDelegate(address _delegate)
+    function setVotingProxy(uint32 _ship, address _voter)
       external
+      activeShipOwner(_ship)
     {
-      ships.setDelegate(msg.sender, _delegate);
+      ships.setVotingProxy(_ship, _voter);
     }
 
     //  startConstitutionPoll(): as _galaxy, start a poll for the constitution

--- a/contracts/Constitution.sol
+++ b/contracts/Constitution.sol
@@ -309,12 +309,11 @@ contract Constitution is ConstitutionBase, ERC165Mapping, ERC721Metadata
     //    Requirements:
     //    - _ship must not be active,
     //    - _ship must not be a planet with a galaxy prefix,
-    //    - _ship's prefix must be active and under its spawn limit,
+    //    - _ship's prefix must be booted and under its spawn limit,
     //    - :msg.sender must be either the owner of _ship's prefix,
     //      or an authorized spawn proxy for it.
     //
-    function spawn(uint32 _ship,
-                   address _target)
+    function spawn(uint32 _ship, address _target)
       external
     {
       //  only currently unowned (and thus also inactive) ships can be spawned

--- a/contracts/Constitution.sol
+++ b/contracts/Constitution.sol
@@ -527,6 +527,14 @@ contract Constitution is ConstitutionBase, ERC165Mapping, ERC721Metadata
           ships.setKeys(_ship, 0, 0, 0);
         }
 
+        //  clear management proxy
+        //
+        ships.setManagementProxy(_ship, 0);
+
+        //  clear voting proxy
+        //
+        ships.setVotingProxy(_ship, 0);
+
         //  clear transfer proxy
         //
         //    in most cases this is done above, during the ownership transfer,

--- a/contracts/Constitution.sol
+++ b/contracts/Constitution.sol
@@ -645,54 +645,49 @@ contract Constitution is ConstitutionBase, ERC165Mapping, ERC721Metadata
       ships.cancelEscape(_ship);
     }
 
-    //  adopt(): as the _sponsor, accept the _escapee
+    //  adopt(): as the _sponsor, accept the _ship
     //
     //    Requirements:
-    //    - :msg.sender must be the owner of _sponsor,
-    //    - _escapee must currently be trying to escape to _sponsor.
+    //    - :msg.sender must be the owner of _ship's requested sponsor.
     //
-    function adopt(uint32 _sponsor, uint32 _escapee)
+    function adopt(uint32 _ship)
       external
-      activeShipManager(_sponsor)
     {
-      require(ships.isRequestingEscapeTo(_escapee, _sponsor));
+      require( ships.isEscaping(_ship) &&
+               ships.canManage(ships.getEscapeRequest(_ship), msg.sender) );
 
-      //  _sponsor becomes _escapee's sponsor
+      //  _sponsor becomes _ship's sponsor
       //  its escape request is reset to "not escaping"
       //
-      ships.doEscape(_escapee);
+      ships.doEscape(_ship);
     }
 
-    //  reject(): as the _sponsor, deny the _escapee's request
+    //  reject(): as the _sponsor, deny the _ship's request
     //
     //    Requirements:
-    //    - :msg.sender must be the owner of _sponsor,
-    //    - _escapee must currently be trying to escape to _sponsor.
+    //    - :msg.sender must be the owner of _ship's requested sponsor.
     //
-    function reject(uint32 _sponsor, uint32 _escapee)
+    function reject(uint32 _ship)
       external
-      activeShipManager(_sponsor)
     {
-      require(ships.isRequestingEscapeTo(_escapee, _sponsor));
+      require( ships.isEscaping(_ship) &&
+               ships.canManage(ships.getEscapeRequest(_ship), msg.sender) );
 
-      //  reset the _escapee's escape request to "not escaping"
+      //  reset the _ship's escape request to "not escaping"
       //
-      ships.cancelEscape(_escapee);
+      ships.cancelEscape(_ship);
     }
 
     //  detach(): as the _sponsor, stop sponsoring the _ship
     //
     //    Requirements:
-    //    - :msg.sender must be the owner of _sponsor,
-    //    - _ship must currently be sponsored by _sponsor.
+    //    - :msg.sender must be the owner of _ship's current sponsor.
     //
-    function detach(uint32 _sponsor, uint32 _ship)
+    function detach(uint32 _ship)
       external
-      activeShipManager(_sponsor)
     {
-      //  only the current and active sponsor may do this
-      //
-      require(ships.isSponsor(_ship, _sponsor));
+      require( ships.hasSponsor(_ship) &&
+               ships.canManage(ships.getSponsor(_ship), msg.sender) );
 
       //  signal that _sponsor no longer supports _ship
       //

--- a/test/TestConstitution.js
+++ b/test/TestConstitution.js
@@ -134,6 +134,8 @@ contract('Constitution', function([owner, user1, user2]) {
   it('transfering ownership directly', async function() {
     assert.equal(await ships.getContinuityNumber(0), 0);
     // set values that should be cleared on-transfer.
+    await constit.setManagementProxy(0, owner, {from:user1});
+    await constit.setVotingProxy(0, owner, {from:user1});
     await constit.setSpawnProxy(0, owner, {from:user1});
     await constit.setTransferProxy(0, owner, {from:user1});
     await claims.addClaim(0, "protocol", "claim", "proof", {from:user1});
@@ -150,8 +152,10 @@ contract('Constitution', function([owner, user1, user2]) {
       '0x0000000000000000000000000000000000000000000000000000000000000000');
     assert.equal(await ships.getKeyRevisionNumber(0), 2);
     assert.equal(await ships.getContinuityNumber(0), 1);
-    assert.isFalse(await ships.isSpawnProxy(0, user2));
-    assert.isFalse(await ships.isTransferProxy(0, user2));
+    assert.isTrue(await ships.isManagementProxy(0, 0));
+    assert.isTrue(await ships.isVotingProxy(0, 0));
+    assert.isTrue(await ships.isSpawnProxy(0, 0));
+    assert.isTrue(await ships.isTransferProxy(0, 0));
     let claim = await claims.claims(0, 0);
     assert.equal(claim[0], "");
     // for unbooted ships, keys/continuity aren't incremented

--- a/test/TestConstitution.js
+++ b/test/TestConstitution.js
@@ -242,28 +242,26 @@ contract('Constitution', function([owner, user1, user2]) {
 
   it('adopting or reject an escaping ship', async function() {
     // can't if not owner of parent.
-    await assertRevert(constit.adopt(1, 256, {from:user2}));
-    await assertRevert(constit.reject(1, 512, {from:user2}));
+    await assertRevert(constit.adopt(256, {from:user2}));
+    await assertRevert(constit.reject(512, {from:user2}));
     // can't if target is not escaping to parent.
-    await assertRevert(constit.adopt(1, 258, {from:user1}));
-    await assertRevert(constit.reject(1, 258, {from:user1}));
+    await assertRevert(constit.adopt(258, {from:user1}));
+    await assertRevert(constit.reject(258, {from:user1}));
     // adopt as parent owner.
-    await constit.adopt(1, 256, {from:user1});
+    await constit.adopt(256, {from:user1});
     assert.isFalse(await ships.isRequestingEscapeTo(256, 1));
     assert.equal(await ships.getSponsor(256), 1);
     assert.isTrue(await ships.isSponsor(256, 1));
     // reject as parent owner.
-    await constit.reject(1, 512, {from:user1});
+    await constit.reject(512, {from:user1});
     assert.isFalse(await ships.isRequestingEscapeTo(512, 1));
     assert.equal(await ships.getSponsor(512), 0);
   });
 
   it('detaching sponsorship', async function() {
     // can't if not owner of sponsor
-    await assertRevert(constit.detach(1, 256, {from:user2}));
-    // can't if not sponsor of ship
-    await assertRevert(constit.detach(1, 512, {from:user1}));
-    await constit.detach(1, 256, {from:user1});
+    await assertRevert(constit.detach(256, {from:user2}));
+    await constit.detach(256, {from:user1});
     assert.isFalse(await ships.isSponsor(256, 1));
     assert.equal(await ships.getSponsor(256), 1);
   });

--- a/test/TestConstitution.js
+++ b/test/TestConstitution.js
@@ -203,10 +203,10 @@ contract('Constitution', function([owner, user1, user2]) {
     assert.equal(await ships.getContinuityNumber(0), 2);
   });
 
-  it('setting manager', async function() {
-    assert.equal(await ships.managers(user1), 0);
-    await constit.setManager(owner, {from:user1});
-    assert.equal(await ships.managers(user1), owner);
+  it('setting management proxy', async function() {
+    assert.equal(await ships.getManagementProxy(0), 0);
+    await constit.setManagementProxy(0, owner, {from:user1});
+    assert.equal(await ships.getManagementProxy(0), owner);
     // manager can do things like configure keys
     await constit.configureKeys(0, 9, 9, 1, false, {from:owner});
   });
@@ -268,10 +268,10 @@ contract('Constitution', function([owner, user1, user2]) {
     assert.equal(await ships.getSponsor(256), 1);
   });
 
-  it('setting manager', async function() {
-    assert.equal(await ships.delegates(user1), 0);
-    await constit.setDelegate(owner, {from:user1});
-    assert.equal(await ships.delegates(user1), owner);
+  it('setting voting proxy', async function() {
+    assert.equal(await ships.getVotingProxy(0), 0);
+    await constit.setVotingProxy(0, owner, {from:user1});
+    assert.equal(await ships.getVotingProxy(0), owner);
   });
 
   it('voting on and updating document poll', async function() {

--- a/test/TestShips.js
+++ b/test/TestShips.js
@@ -180,75 +180,62 @@ contract('Ships', function([owner, user, user2, user3]) {
     assert.equal(await ships.getContinuityNumber(0), 1);
   });
 
-  it('setting manager', async function() {
-    await ships.setOwner(0, user);
-    assert.isFalse(await ships.canManage(0, owner));
-    assert.isFalse(await ships.isManager(user, owner));
-    assert.equal(await ships.getManagingForCount(owner), 0);
+  it('setting management proxy', async function() {
+    assert.isFalse(await ships.isManagementProxy(0, owner));
+    assert.equal(await ships.getManagerForCount(owner), 0);
     // only owner can do this.
-    await assertRevert(ships.setManager(user, owner, {from:user}));
-    await seeEvents(ships.setManager(user, owner), ['ChangedManager']);
+    await assertRevert(ships.setManagementProxy(0, owner, {from:user}));
+    await seeEvents(ships.setManagementProxy(0, owner), ['ChangedManagementProxy']);
     // won't emit event when nothing changes
-    await seeEvents(ships.setManager(user, owner), []);
-    await ships.setManager(user2, owner);
-    await ships.setManager(user3, owner);
-    assert.equal(await ships.managers(user), owner);
-    assert.isTrue(await ships.canManage(0, owner));
-    assert.isTrue(await ships.isManager(user, owner));
-    assert.equal(await ships.getManagingForCount(owner), 3);
-    assert.equal(await ships.managingForIndexes(owner, user), 1);
-    let mf = await ships.getManagingFor(owner);
-    assert.equal(mf[0], user);
-    assert.equal(mf[1], user2);
-    assert.equal(mf[2], user3);
-    await ships.setManager(user, 0);
-    assert.isFalse(await ships.canManage(0, owner));
-    assert.equal(await ships.getManagingForCount(owner), 2);
-    assert.equal(await ships.managingForIndexes(owner, user), 0);
-    mf = await ships.getManagingFor(owner);
-    assert.equal(mf[0], user3);
-    assert.equal(mf[1], user2);
+    await seeEvents(ships.setManagementProxy(0, owner), []);
+    await ships.setManagementProxy(1, owner);
+    await ships.setManagementProxy(2, owner);
+    assert.equal(await ships.getManagementProxy(0), owner);
+    assert.isTrue(await ships.isManagementProxy(0, owner));
+    assert.equal(await ships.getManagerForCount(owner), 3);
+    assert.equal(await ships.managerForIndexes(owner, 0), 1);
+    let stt = await ships.getManagerFor(owner);
+    assert.equal(stt[0], 0);
+    assert.equal(stt[1], 1);
+    assert.equal(stt[2], 2);
+    await ships.setManagementProxy(0, 0);
+    assert.isFalse(await ships.isManagementProxy(0, owner));
+    assert.equal(await ships.getManagerForCount(owner), 2);
+    assert.equal(await ships.managerForIndexes(owner, 0), 0);
+    stt = await ships.getManagerFor(owner);
+    assert.equal(stt[0], 2);
+    assert.equal(stt[1], 1);
     // can still interact with ships that got shuffled around in array
-    await ships.setManager(user3, 0);
-    await ships.setManager(user2, 0);
-    assert.equal(await ships.managingForIndexes(owner, user2), 0);
-    assert.equal(await ships.managingForIndexes(owner, user3), 0);
-    assert.equal(await ships.managers(user3), 0);
+    await ships.setManagementProxy(2, 0);
   });
 
-  it('setting vote delegate', async function() {
-    assert.isFalse(await ships.canVoteAs(0, owner));
-    assert.isFalse(await ships.isDelegate(user, owner));
+  it('setting voting proxy', async function() {
+    assert.isFalse(await ships.isVotingProxy(0, owner));
     assert.equal(await ships.getVotingForCount(owner), 0);
     // only owner can do this.
-    await assertRevert(ships.setDelegate(user, owner, {from:user}));
-    await seeEvents(ships.setDelegate(user, owner), ['ChangedDelegate']);
+    await assertRevert(ships.setVotingProxy(0, owner, {from:user}));
+    await seeEvents(ships.setVotingProxy(0, owner), ['ChangedVotingProxy']);
     // won't emit event when nothing changes
-    await seeEvents(ships.setDelegate(user, owner), []);
-    await ships.setDelegate(user2, owner);
-    await ships.setDelegate(user3, owner);
-    assert.equal(await ships.delegates(user), owner);
-    assert.isTrue(await ships.canVoteAs(0, owner));
-    assert.isTrue(await ships.isDelegate(user, owner));
+    await seeEvents(ships.setVotingProxy(0, owner), []);
+    await ships.setVotingProxy(1, owner);
+    await ships.setVotingProxy(2, owner);
+    assert.equal(await ships.getVotingProxy(0), owner);
+    assert.isTrue(await ships.isVotingProxy(0, owner));
     assert.equal(await ships.getVotingForCount(owner), 3);
-    assert.equal(await ships.votingForIndexes(owner, user), 1);
-    let vf = await ships.getVotingFor(owner);
-    assert.equal(vf[0], user);
-    assert.equal(vf[1], user2);
-    assert.equal(vf[2], user3);
-    await ships.setDelegate(user, 0);
-    assert.isFalse(await ships.canVoteAs(0, owner));
+    assert.equal(await ships.votingForIndexes(owner, 0), 1);
+    let stt = await ships.getVotingFor(owner);
+    assert.equal(stt[0], 0);
+    assert.equal(stt[1], 1);
+    assert.equal(stt[2], 2);
+    await ships.setVotingProxy(0, 0);
+    assert.isFalse(await ships.isVotingProxy(0, owner));
     assert.equal(await ships.getVotingForCount(owner), 2);
-    assert.equal(await ships.votingForIndexes(owner, user), 0);
-    vf = await ships.getVotingFor(owner);
-    assert.equal(vf[0], user3);
-    assert.equal(vf[1], user2);
+    assert.equal(await ships.votingForIndexes(owner, 0), 0);
+    stt = await ships.getVotingFor(owner);
+    assert.equal(stt[0], 2);
+    assert.equal(stt[1], 1);
     // can still interact with ships that got shuffled around in array
-    await ships.setDelegate(user3, 0);
-    await ships.setDelegate(user2, 0);
-    assert.equal(await ships.votingForIndexes(owner, user2), 0);
-    assert.equal(await ships.votingForIndexes(owner, user3), 0);
-    assert.equal(await ships.delegates(user3), 0);
+    await ships.setVotingProxy(2, 0);
   });
 
   it('setting spawn proxy', async function() {


### PR DESCRIPTION
Lowercase f there just in case. This does two things.

First, it turns the per-owner managers and delegates into per-ship management proxies and voting proxies. In doing so, we refactor the whole set of permissions-related addresses out of the `Hull` and into the `Deed`. The `Hull` struct was hitting the limits of what Solidity supports, deep sigh, but I think we ended up with actually kinda nice code.

Secondly, it simplifies the interfaces for `adopt`, `reject` and `detach`, to no longer require the caller to specify the sponsor they want to use, since that can be deduced by the contract logic perfectly fine. Permissions model for these remains the same, it's really just an aesthetic change.

Changes here will have to be propagated into the various places the Constitution is used directly. Unless I'm forgetting something, that's constitution-js and jael/zuse. (The changes wrt managers/delegates also touch ceremony transaction generation, but that was still partly in flux anyway.)