### PR TITLE
Reverse lookup for sponsors

### DIFF
--- a/contracts/ConditionalStarRelease.sol
+++ b/contracts/ConditionalStarRelease.sol
@@ -12,7 +12,7 @@ import 'openzeppelin-solidity/contracts/ownership/Ownable.sol';
 //    recipient (also "participant") gradually over time, assuming
 //    the specified conditions are met.
 //
-//    This contract represents a single set of conditions and corrosponding
+//    This contract represents a single set of conditions and corresponding
 //    deadlines (up to eight) which get configured during contract creation.
 //    The conditions take the form of hashes, and they are checked for
 //    by looking at the Polls contract. A condition is met if it has

--- a/contracts/Constitution.sol
+++ b/contracts/Constitution.sol
@@ -49,9 +49,23 @@ contract Constitution is ConstitutionBase, ERC165Mapping, ERC721Metadata
   using SafeMath for uint256;
   using AddressUtils for address;
 
+  //  Transfer: This emits when ownership of any NFT changes by any mechanism.
+  //            This event emits when NFTs are created (`from` == 0) and
+  //            destroyed (`to` == 0). At the time of any transfer, the approved
+  //            address for that NFT (if any) is reset to none.
+  //
   event Transfer(address indexed _from, address indexed _to, uint256 _tokenId);
+
+  //  Approval: This emits when the approved address for an NFT is changed or
+  //            reaffirmed. The zero address indicates there is no approved
+  //            address. When a Transfer event emits, this also indicates that
+  //            the approved address for that NFT (if any) is reset to none.
   event Approval(address indexed _owner, address indexed _approved,
                  uint256 _tokenId);
+
+  //  ApprovalForAll: This emits when an operator is enabled or disabled for an
+  //                  owner. The operator can manage all NFTs of the owner.
+  //
   event ApprovalForAll(address indexed _owner, address indexed _operator,
                        bool _approved);
 
@@ -557,7 +571,7 @@ contract Constitution is ConstitutionBase, ERC165Mapping, ERC721Metadata
     //
     //    Requirements:
     //    - :msg.sender must be either _ship's current owner, or be
-    //      allowed to manage the current owner's ships.
+    //      allowed to operate the current owner's ships.
     //
     function setTransferProxy(uint32 _ship, address _transferProxy)
       public

--- a/contracts/Ships.sol
+++ b/contracts/Ships.sol
@@ -14,9 +14,9 @@ import 'openzeppelin-solidity/contracts/ownership/Ownable.sol';
 //    ownership of all ships owned by their associated address
 //    (ERC721's approveAll()). A transfer proxy is allowed to transfer
 //    ownership of a single ship (ERC721's approve()).
-//    Separate from ERC721 are managers, assigned per owner address.
-//    They are allowed to perform "low-impact" operations on the owner's
-//    ships, like configuring public keys and making escape requests.
+//    Separate from ERC721 are managers, assigned per ship. They are
+//    allowed to perform "low-impact" operations on the owner's ships,
+//    like configuring public keys and making escape requests.
 //
 //    Since data stores are difficult to upgrade, this contract contains
 //    as little actual business logic as possible. Instead, the data stored
@@ -116,11 +116,11 @@ contract Ships is Ownable
     //
     bytes32 authenticationKey;
 
-    //  cryptoSuiteNumber: version of the Urbit crypto suite used
+    //  cryptoSuiteVersion: version of the Urbit crypto suite used
     //
     uint32 cryptoSuiteVersion;
 
-    //  keyRevisionNumber: incremented every time we change the keys
+    //  keyRevisionNumber: incremented every time we change the Urbit keys
     //
     uint32 keyRevisionNumber;
 


### PR DESCRIPTION
This implements reverse lookups for sponsorship and escape requests. You can now look up, per ship, what other ships you are sponsoring, and what ships have unanswered escape requests to you.  
Yes, I'll add those into constitution-js when this gets merged.

Also adds/cleans up some comments.