### PR TITLE
Move responsibility for ENS resolution out of the Constitution

### DIFF
--- a/contracts/Constitution.sol
+++ b/contracts/Constitution.sol
@@ -88,11 +88,8 @@ contract Constitution is ConstitutionBase, ERC165Mapping, ERC721Metadata
   constructor(address _previous,
               Ships _ships,
               Polls _polls,
-              ENS _ensRegistry,
-              string _baseEns,
-              string _subEns,
               Claims _claims)
-    ConstitutionBase(_previous, _ships, _polls, _ensRegistry, _baseEns, _subEns)
+    ConstitutionBase(_previous, _ships, _polls)
     public
   {
     claims = _claims;

--- a/contracts/ConstitutionResolver.sol
+++ b/contracts/ConstitutionResolver.sol
@@ -1,0 +1,38 @@
+//  ENS resolver for the Constitution contract
+
+pragma solidity 0.4.24;
+
+import './interfaces/ResolverInterface.sol';
+import './Ships.sol';
+
+contract ConstitutionResolver
+{
+  Ships ships;
+
+  constructor(Ships _ships)
+  {
+    ships = _ships;
+  }
+
+  function addr(bytes32 node)
+    constant
+    returns (address)
+  {
+    //  resolve to the Constitution contract
+    return ships.owner();
+  }
+
+  function supportsInterface(bytes4 interfaceID)
+    constant
+    returns (bool)
+  {
+    //  supports ERC-137 addr() and ERC-165
+    return interfaceID == 0x3b3b57de || interfaceID == 0x01ffc9a7;
+  }
+
+  //  ERC-137 resolvers MUST specify a fallback function that throws
+  function()
+  {
+    revert();
+  }
+}

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -45,7 +45,7 @@ module.exports = async function(deployer) {
     //NOTE  for real deployment, we'll want to use a real ENS registry
     //      and node names
     return deployer.deploy(Constitution, 0, ships.address, polls.address,
-                                         0, '', '', claims.address);
+                                         claims.address);
   }).then(function() {
     return Constitution.deployed();
   }).then(async function(instance) {

--- a/test/TestConditionalStarRelease.js
+++ b/test/TestConditionalStarRelease.js
@@ -41,7 +41,7 @@ contract('Conditional Star Release', function([owner, user1, user2, user3]) {
     polls = await Polls.new(432000, 432000);
     claims = await Claims.new(ships.address);
     constit = await Constitution.new(0, ships.address, polls.address,
-                                     0, '', '', claims.address);
+                                     claims.address);
     await ships.transferOwnership(constit.address);
     await polls.transferOwnership(constit.address);
     await constit.createGalaxy(0, owner);

--- a/test/TestConstitution.js
+++ b/test/TestConstitution.js
@@ -12,42 +12,15 @@ const seeEvents = require('./helpers/seeEvents');
 contract('Constitution', function([owner, user1, user2]) {
   let ships, polls, claims, ens, resolver, constit, consti2, pollTime;
 
-  // https://github.com/ethereum/ens/blob/master/ensutils.js
-  function namehash(name) {
-    var node =
-      '0x0000000000000000000000000000000000000000000000000000000000000000';
-    if (name != '') {
-      var labels = name.split(".");
-      for(var i = labels.length - 1; i >= 0; i--) {
-        node = web3.sha3(node + web3.sha3(labels[i]).slice(2), {encoding: 'hex'});
-      }
-    }
-    return node.toString();
-  }
-
   before('setting up for tests', async function() {
     pollTime = 432000;
     ships = await Ships.new();
     polls = await Polls.new(pollTime, pollTime);
     claims = await Claims.new(ships.address);
-    ens = await ENSRegistry.new();
-    resolver = await PublicResolver.new(ens.address);
-    await ens.setSubnodeOwner(0, web3.sha3('eth'), owner);
     constit = await Constitution.new(0, ships.address, polls.address,
-                                     ens.address, 'foo', 'sub',
                                      claims.address);
-    assert.equal(await constit.baseNode(), namehash('foo.eth'));
-    assert.equal(await constit.subNode(), namehash('sub.foo.eth'));
     await ships.transferOwnership(constit.address);
     await polls.transferOwnership(constit.address);
-    await ens.setSubnodeOwner(namehash('eth'), web3.sha3('foo'), owner);
-    await ens.setSubnodeOwner(namehash('foo.eth'),
-                              web3.sha3('sub'),
-                              owner);
-    await ens.setResolver(namehash('foo.eth'), resolver.address);
-    await resolver.setAddr(namehash('sub.foo.eth'), constit.address);
-    await ens.setOwner(namehash('foo.eth'), constit.address);
-    await ens.setOwner(namehash('sub.foo.eth'), constit.address);
   });
 
   it('setting dns domains', async function() {
@@ -293,12 +266,10 @@ contract('Constitution', function([owner, user1, user2]) {
     constix = await Constitution.new('0x0',
                                      ships.address,
                                      polls.address,
-                                     ens.address, 'foo', 'sub',
                                      claims.address);
     consti2 = await Constitution.new(constit.address,
                                      ships.address,
                                      polls.address,
-                                     ens.address, 'foo', 'sub',
                                      claims.address);
     // can't if upgrade path not correct
     await assertRevert(constit.startConstitutionPoll(0, constix.address, {from:user1}));
@@ -311,17 +282,12 @@ contract('Constitution', function([owner, user1, user2]) {
     await constit.castConstitutionVote(1, consti2.address, true, {from:user1});
     assert.equal(await ships.owner(), consti2.address);
     assert.equal(await polls.owner(), consti2.address);
-    assert.equal(await ens.owner(namehash('foo.eth')), consti2.address);
-    assert.equal(await ens.owner(namehash('sub.foo.eth')), consti2.address);
-    assert.equal(await resolver.addr(namehash('sub.foo.eth')),
-                  consti2.address);
   });
 
   it('updating constituton poll', async function() {
     let consti3 = await Constitution.new(consti2.address,
                                          ships.address,
                                          polls.address,
-                                         ens.address, 'foo', 'sub',
                                          claims.address);
     // onUpgrade can only be called by previous constitution
     await assertRevert(consti3.onUpgrade({from:user2}));
@@ -335,9 +301,5 @@ contract('Constitution', function([owner, user1, user2]) {
                     ['Upgraded', 'OwnershipTransferred']);
     assert.equal(await ships.owner(), consti3.address);
     assert.equal(await polls.owner(), consti3.address);
-    assert.equal(await ens.owner(namehash('foo.eth')), consti3.address);
-    assert.equal(await ens.owner(namehash('sub.foo.eth')), consti3.address);
-    assert.equal(await resolver.addr(namehash('sub.foo.eth')),
-                  consti3.address);
   });
 });

--- a/test/TestDelegatedSending.js
+++ b/test/TestDelegatedSending.js
@@ -22,7 +22,7 @@ contract('Delegated Sending', function([owner, user1, user2, user3, user4]) {
     polls = await Polls.new(432000, 432000);
     claims = await Claims.new(ships.address);
     constit = await Constitution.new(0, ships.address, polls.address,
-                                     0, '', '', claims.address);
+                                     claims.address);
     await ships.transferOwnership(constit.address);
     await polls.transferOwnership(constit.address);
     dese = await DelegatedSending.new(ships.address);

--- a/test/TestERC721Constitution.js
+++ b/test/TestERC721Constitution.js
@@ -53,7 +53,7 @@ contract('NFTokenMock', (accounts) => {
     ships = await Ships.new();
     polls = await Polls.new(432000, 432000);
     claims = await Claims.new(ships.address);
-    nftoken = await Constitution.new(0, ships.address, polls.address, 0, '', '', claims.address);
+    nftoken = await Constitution.new(0, ships.address, polls.address, claims.address);
     ships.transferOwnership(nftoken.address);
     polls.transferOwnership(nftoken.address);
   });

--- a/test/TestERC721Extensions.js
+++ b/test/TestERC721Extensions.js
@@ -19,7 +19,7 @@ contract('NFTokenMetadataMock', (accounts) => {
     ships = await Ships.new();
     polls = await Polls.new(432000, 432000);
     claims = await Claims.new(ships.address);
-    nftoken = await Constitution.new(0, ships.address, polls.address, 0, '', '', claims.address);
+    nftoken = await Constitution.new(0, ships.address, polls.address, claims.address);
     ships.transferOwnership(nftoken.address);
     polls.transferOwnership(nftoken.address);
   });

--- a/test/TestLinearStarRelease.js
+++ b/test/TestLinearStarRelease.js
@@ -17,7 +17,7 @@ contract('Linear Star Release', function([owner, user1, user2, user3]) {
     polls = await Polls.new(432000, 432000);
     claims = await Claims.new(ships.address);
     constit = await Constitution.new(0, ships.address, polls.address,
-                                     0, '', '', claims.address);
+                                     claims.address);
     await ships.transferOwnership(constit.address);
     await polls.transferOwnership(constit.address);
     await constit.createGalaxy(0, owner);

--- a/test/TestPlanetSale.js
+++ b/test/TestPlanetSale.js
@@ -15,7 +15,7 @@ contract('Planet Sale', function([owner, user]) {
     polls = await Polls.new(432000, 432000);
     claims = await Claims.new(ships.address);
     constit = await Constitution.new(0, ships.address, polls.address,
-                                     0, '', '', claims.address);
+                                     claims.address);
     await ships.transferOwnership(constit.address);
     await polls.transferOwnership(constit.address);
     await constit.createGalaxy(0, owner);

--- a/test/TestPool.js
+++ b/test/TestPool.js
@@ -14,7 +14,7 @@ contract('Pool', function([owner, user1, user2]) {
     polls = await Polls.new(432000, 432000);
     claims = await Claims.new(ships.address);
     constit = await Constitution.new(0, ships.address, polls.address,
-                                     0, '', '', claims.address);
+                                     claims.address);
     await ships.transferOwnership(constit.address);
     await polls.transferOwnership(constit.address);
     await constit.createGalaxy(0, user1);


### PR DESCRIPTION
By having a simple resolver to keep pointing to the Constitution, we simplify the logic here.

Note that this still doesn't mean we (as Tlon) have fully decentralized/given up ownership of the ENS (sub)domains, but this does enable us to realize that independently of the contracts.